### PR TITLE
CI setup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,9 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio", from: "2.51.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.17.0"),
-        .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.1.0")),
+        // FIXME: swift-openapi-runtime is private, so we can't access it anonymously yet
+        //.package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.1.0")),
+        .package(url: "git@github.com:apple/swift-openapi-runtime.git", .upToNextMinor(from: "0.1.0")),        
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [


### PR DESCRIPTION
Motivation:
swift-openapi-runtime is private, so it can't be accessed anonymously and CI fails.

Modifications:
- Change to use SSH git URL for swift-openapi-runtime
- Set up SSH access in CI temporarily until swift-openapi-runtime becomes public.


_[Describe the steps you took, or will take, to qualify the change - such as adjusting tests and manual testing.]_
