### PR TITLE
Use an SSH URL to fetch Runtime in CI

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -15,6 +15,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    # Note: This temporary step creates a gitconfig to use SSH for a dependency
+    # that is not yet public. This can be removed once it is public.
+    command: git config --global url."git@github.com:apple/swift-openapi-runtime".insteadOf "https://github.com/apple/swift-openapi-runtime"
+    volumes:
+      - ci-gitconfig:/ci-gitconfig
+    environment:
+      - GIT_CONFIG_GLOBAL=/ci-gitconfig/gitconfig
 
   common: &common
     image: *image
@@ -22,7 +29,10 @@ services:
     volumes:
       - ~/.ssh:/root/.ssh
       - ..:/code:z
+      - ci-gitconfig:/ci-gitconfig
     working_dir: /code
+    environment:
+      - GIT_CONFIG_GLOBAL=/ci-gitconfig/gitconfig
 
   soundness:
     <<: *common
@@ -35,3 +45,6 @@ services:
   shell:
     <<: *common
     entrypoint: /bin/bash
+
+volumes:
+  ci-gitconfig:


### PR DESCRIPTION
(Same as: https://github.com/apple/swift-openapi-generator/pull/3)

### Motivation

Until the swift-openapi-runtime repository is made public, it cannot be
cloned using a HTTPS package URL without authentication, which is what
this package is using in its Package.swift.

This means CI isn't able to run for this package. However, CI is able to
clone this repository over SSH, which presents an opportunity for a
temporary workaround.

### Modifications

Add a temporary step to the Docker Compose CI flow, which creates a Git
config in a shared ephemeral volume with the following contents:

```gitconfig
[url "git@github.com:apple/swift-openapi-runtime"]
        insteadOf = https://github.com/apple/swift-openapi-runtime
```

### Result

The CI should be able to clone the private dependency and then succeed.

### Test Plan

Locally, this works:

```console
❯ docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.2204.58.yaml run test
...
+ swift test -Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error
...
Fetching https://github.com/apple/swift-openapi-runtime
...
Fetched https://github.com/apple/swift-openapi-runtime (2.68s)
...
Executed 86 tests, with 0 failures (0 unexpected) in 3.265 (3.265) seconds
```

Also, if we use can use the `shell` Docker Compose service to see things
are configured correctly:

```console
root@20ab69e3f292:/code# echo $GIT_CONFIG_GLOBAL
/ci-gitconfig/gitconfig
root@20ab69e3f292:/code# cat $GIT_CONFIG_GLOBAL
[url "git@github.com:apple/swift-openapi-runtime"]
        insteadOf = https://github.com/apple/swift-openapi-runtime
```
