### PR TITLE
[Releases] Add a GitHub release config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,15 @@
+changelog:
+  categories:
+    - title: SemVer Major
+      labels:
+        - semver/major
+    - title: SemVer Minor
+      labels:
+        - semver/minor
+    - title: SemVer Patch
+      labels:
+        - semver/patch
+    - title: Other Changes
+      labels:
+        - semver/none
+        - "*"


### PR DESCRIPTION
### Motivation

This config helps compose release notes easier.

### Modifications

Added a config file that instructs GitHub how to group PRs.

### Result

Releases can be mostly generated now.

### Test Plan

N/A
