### PR TITLE
Disable ExistentialAny temporarily

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,13 +15,6 @@
 import Foundation
 import PackageDescription
 
-// General Swift-settings for all targets.
-let swiftSettings: [SwiftSetting] = [
-    // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
-    // Require `any` for existential types.
-    .enableUpcomingFeature("ExistentialAny")
-]
-
 let package = Package(
     name: "swift-openapi-async-http-client",
     platforms: [
@@ -46,15 +39,13 @@ let package = Package(
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
-            ],
-            swiftSettings: swiftSettings
+            ]
         ),
         .testTarget(
             name: "OpenAPIAsyncHTTPClientTests",
             dependencies: [
                 "OpenAPIAsyncHTTPClient",
-            ],
-            swiftSettings: swiftSettings
+            ]
         ),
     ]
 )


### PR DESCRIPTION
### Motivation

Unfortunately until we adopt 5.9, adding ExistentialAny on upstream packages has unintended consequences for some downstream packages, so disabling for now. Details in https://github.com/apple/swift-openapi-generator/issues/120

### Modifications

Disabled the feature enforcement, but the code changes are there, so downstream adopters can still use them.

### Result

We won't be seeing the issue described in https://github.com/apple/swift-openapi-generator/issues/120.

### Test Plan

PR CI, which discovered the original issue.
