### PR TITLE
[AHCTransport] Consistent style for initializing local variables

### DIFF
--- a/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
+++ b/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
@@ -63,7 +63,7 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
     }
 
     func testConvertResponse() async throws {
-        let httpResponse: HTTPClientResponse = .init(
+        let httpResponse = HTTPClientResponse(
             status: .ok,
             headers: [
                 "content-type": "application/json"
@@ -83,7 +83,7 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
 
     func testSend() async throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let httpClient: HTTPClient = .init(
+        let httpClient = HTTPClient(
             eventLoopGroupProvider: .shared(eventLoopGroup),
             configuration: .init()
         )


### PR DESCRIPTION
### Motivation

Move to a consistent style when initializing local variables, always use `let foo = Foo(...)` vs `let foo: Foo = .init(...)`.

### Modifications

Updated all occurrences of the latter to use the former.

### Result

Consistent local variable initialization.

### Test Plan

All tests passed.
