### PR TITLE
Enable strict concurrency checking in CI

### DIFF
--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -15,8 +15,15 @@ import OpenAPIRuntime
 import AsyncHTTPClient
 import NIOCore
 import NIOHTTP1
-import Foundation
 import NIOFoundationCompat
+#if canImport(Darwin)
+import Foundation
+#else
+@preconcurrency import struct Foundation.URL
+import struct Foundation.URLComponents
+import struct Foundation.Data
+import protocol Foundation.LocalizedError
+#endif
 
 /// A client transport that performs HTTP operations using the HTTPClient type
 /// provided by the AsyncHTTPClient library.

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -13,6 +13,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
+      - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
 
   shell:
     image: *image

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -12,6 +12,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
+      - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
 
   shell:
     image: *image

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -12,6 +12,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
+      - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
 
   shell:
     image: *image

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift $${SWIFT_TEST_VERB-test} $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-}"
+    command: /bin/bash -xcl "swift $${SWIFT_TEST_VERB-test} $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} $${STRICT_CONCURRENCY_ARG-}"
 
   shell:
     <<: *common


### PR DESCRIPTION
### Motivation

To further avoid concurrency bugs, enable complete concurrency checking in CI.

### Modifications

Added the compiler flag to the docker-compose scripts.

### Result

If a warning of this nature comes up, because we have warnings-as-errors, it'll fail CI.

### Test Plan

Locally built without any warnings with the flag enabled.
