### PR TITLE
Prepare being compatible with runtime 0.2.0 release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio", from: "2.51.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.17.0"),
-        .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.1.3")),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", "0.1.3" ..< "0.3.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [


### PR DESCRIPTION
### Motivation

Runtime 0.2.0 is compatible with 0.1.3+ in the APIs adopted in the transport, so just reflect that in the manifest.

### Modifications

Increased the supported runtime range to include 0.2.x.

### Result

Once released, folks will be able to use 0.1.x of this transport with both 0.1.x and 0.2.x of runtime.

### Test Plan

Will be manually tested once runtime 0.2.0 is released.
