### PR TITLE
Adopt the new shared HTTP client

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,8 +38,8 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio", from: "2.51.0"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.17.0"),
+        .package(url: "https://github.com/apple/swift-nio", from: "2.58.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.1.3")),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],

--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -30,23 +30,9 @@ import protocol Foundation.LocalizedError
 ///
 /// ### Use the AsyncHTTPClient transport
 ///
-/// Create the underlying HTTP client:
+/// Instantiate the transport:
 ///
-///     let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
-///
-/// Either store a reference to the client elsewhere and shut it down during
-/// cleanup, or add a defer block if the client is only used in the current
-/// scope:
-///
-///     defer {
-///         try! httpClient.syncShutdown()
-///     }
-///
-/// Instantiate the transport and provide the HTTP client to it:
-///
-///     let transport = AsyncHTTPClientTransport(
-///         configuration: .init(client: httpClient)
-///     )
+///     let transport = AsyncHTTPClientTransport()
 ///
 /// Create the base URL of the server to call using your client. If the server
 /// URL was defined in the OpenAPI document, you find a generated method for it
@@ -68,6 +54,12 @@ import protocol Foundation.LocalizedError
 ///
 ///     let response = try await client.checkHealth(.init())
 ///     // ...
+///
+/// ### Provide a custom Client
+///
+/// The ``AsyncHTTPClientTransport/Configuration-swift.struct`` type allows you
+/// to provide a custom `HTTPClient` and tweak behaviors such as the default
+/// timeout.
 public struct AsyncHTTPClientTransport: ClientTransport {
 
     /// A set of configuration values for the AsyncHTTPClient transport.
@@ -83,7 +75,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
         /// - Parameters:
         ///   - client: The underlying client used to perform HTTP operations.
         ///   - timeout: The request timeout, defaults to 1 minute.
-        public init(client: HTTPClient, timeout: TimeAmount = .minutes(1)) {
+        public init(client: HTTPClient = .init(), timeout: TimeAmount = .minutes(1)) {
             self.client = client
             self.timeout = timeout
         }


### PR DESCRIPTION
### Motivation

Now that SwiftNIO/AsyncHTTPClient have a singleton variant of the `EventLoopGroup`, which allows creating an `HTTPClient` without any argument, let's simplify the initializer of the transport to take advantage of it - bringing it in line with the URLSession transport.

### Modifications

Default the HTTPClient to a new one with a default event loop group, and remove the mandatory shutdown call.

### Result

Adopters can more easily create the AHC transport.

### Test Plan

N/A
