### PR TITLE
Fix double encoding of path parameters

### DIFF
--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -161,7 +161,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
         guard var baseUrlComponents = URLComponents(string: baseURL.absoluteString) else {
             throw Error.invalidRequestURL(request: request, baseURL: baseURL)
         }
-        baseUrlComponents.path += request.path
+        baseUrlComponents.percentEncodedPath += request.path
         baseUrlComponents.percentEncodedQuery = request.query
         guard let url = baseUrlComponents.url else {
             throw Error.invalidRequestURL(request: request, baseURL: baseURL)

--- a/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
+++ b/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
@@ -38,7 +38,7 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
 
     func testConvertRequest() throws {
         let request: OpenAPIRuntime.Request = .init(
-            path: "/hello/Maria",
+            path: "/hello%20world/Maria",
             query: "greeting=Howdy",
             method: .post,
             headerFields: [
@@ -50,7 +50,7 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
             request,
             baseURL: try XCTUnwrap(URL(string: "http://example.com/api/v1"))
         )
-        XCTAssertEqual(httpRequest.url, "http://example.com/api/v1/hello/Maria?greeting=Howdy")
+        XCTAssertEqual(httpRequest.url, "http://example.com/api/v1/hello%20world/Maria?greeting=Howdy")
         XCTAssertEqual(httpRequest.method, .POST)
         XCTAssertEqual(
             httpRequest.headers,


### PR DESCRIPTION
### Motivation

Fixes https://github.com/apple/swift-openapi-generator/issues/251.

### Modifications

Use the already escaped path setter on `URLComponents` to avoid the second encoding pass.

### Result

Path parameters that needed escaping are only escaped once, not twice.

### Test Plan

Adapted the existing unit test to cover a path item that needs escaping.
