### PR TITLE
[AHC Transport] Async bodies + swift-http-types adoption

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio", from: "2.58.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
-        .package(url: "https://github.com/apple/swift-openapi-runtime", "0.1.3" ..< "0.3.0"),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", "0.1.3" ..< "0.3.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+//        .package(url: "https://github.com/guoye-zhang/swift-nio-extras", branch: "http-types"),
     ],
     targets: [
         .target(
@@ -50,6 +51,8 @@ let package = Package(
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
+//                .product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
+//                .product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
             ],
             swiftSettings: swiftSettings
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,6 @@ let package = Package(
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", "0.1.3" ..< "0.3.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-//        .package(url: "https://github.com/guoye-zhang/swift-nio-extras", branch: "http-types"),
     ],
     targets: [
         .target(
@@ -51,8 +50,6 @@ let package = Package(
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
-//                .product(name: "NIOHTTPTypes", package: "swift-nio-extras"),
-//                .product(name: "NIOHTTPTypesHTTP1", package: "swift-nio-extras"),
             ],
             swiftSettings: swiftSettings
         ),

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the package dependency in your `Package.swift`:
 ```swift
 .package(
     url: "https://github.com/swift-server/swift-openapi-async-http-client", 
-    .upToNextMinor(from: "0.2.0")
+    .upToNextMinor(from: "0.3.0")
 ),
 ```
 

--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -173,11 +173,14 @@ public struct AsyncHTTPClientTransport: ClientTransport {
         body: HTTPBody?,
         baseURL: URL
     ) throws -> HTTPClientRequest {
-        guard var baseUrlComponents = URLComponents(string: baseURL.absoluteString) else {
+        guard
+            var baseUrlComponents = URLComponents(string: baseURL.absoluteString),
+            let requestUrlComponents = URLComponents(string: request.path ?? "")
+        else {
             throw Error.invalidRequestURL(request: request, baseURL: baseURL)
         }
-        baseUrlComponents.percentEncodedPath += request.soar_pathOnly
-        baseUrlComponents.percentEncodedQuery = request.soar_query.map(String.init)
+        baseUrlComponents.percentEncodedPath += requestUrlComponents.percentEncodedPath
+        baseUrlComponents.percentEncodedQuery = requestUrlComponents.percentEncodedQuery
         guard let url = baseUrlComponents.url else {
             throw Error.invalidRequestURL(request: request, baseURL: baseURL)
         }

--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -210,7 +210,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
         }
 
         let body = HTTPBody(
-            sequence: httpResponse.body.map { HTTPBody.ByteChunk($0.readableBytesView) },
+            httpResponse.body.map { $0.readableBytesView },
             length: length,
             iterationBehavior: .single
         )

--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -16,6 +16,7 @@ import AsyncHTTPClient
 import NIOCore
 import NIOHTTP1
 import NIOFoundationCompat
+import HTTPTypes
 #if canImport(Darwin)
 import Foundation
 #else
@@ -91,7 +92,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
     internal enum Error: Swift.Error, CustomStringConvertible, LocalizedError {
 
         /// Invalid URL composed from base URL and received request.
-        case invalidRequestURL(request: OpenAPIRuntime.Request, baseURL: URL)
+        case invalidRequestURL(request: HTTPRequest, baseURL: URL)
 
         // MARK: CustomStringConvertible
 
@@ -99,7 +100,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
             switch self {
             case let .invalidRequestURL(request: request, baseURL: baseURL):
                 return
-                    "Invalid request URL from request path: \(request.path), query: \(request.query ?? "<nil>") relative to base URL: \(baseURL.absoluteString)"
+                    "Invalid request URL from request path: \(request.path ?? "<nil>") relative to base URL: \(baseURL.absoluteString)"
             }
         }
 
@@ -141,11 +142,12 @@ public struct AsyncHTTPClientTransport: ClientTransport {
     // MARK: ClientTransport
 
     public func send(
-        _ request: OpenAPIRuntime.Request,
+        _ request: HTTPRequest,
+        body: HTTPBody?,
         baseURL: URL,
         operationID: String
-    ) async throws -> OpenAPIRuntime.Response {
-        let httpRequest = try Self.convertRequest(request, baseURL: baseURL)
+    ) async throws -> (HTTPResponse, HTTPBody) {
+        let httpRequest = try Self.convertRequest(request, body: body, baseURL: baseURL)
         let httpResponse = try await invokeSession(with: httpRequest)
         let response = try await Self.convertResponse(httpResponse)
         return response
@@ -155,24 +157,35 @@ public struct AsyncHTTPClientTransport: ClientTransport {
 
     /// Converts the shared Request type into URLRequest.
     internal static func convertRequest(
-        _ request: OpenAPIRuntime.Request,
+        _ request: HTTPRequest,
+        body: HTTPBody?,
         baseURL: URL
     ) throws -> HTTPClientRequest {
         guard var baseUrlComponents = URLComponents(string: baseURL.absoluteString) else {
             throw Error.invalidRequestURL(request: request, baseURL: baseURL)
         }
-        baseUrlComponents.percentEncodedPath += request.path
-        baseUrlComponents.percentEncodedQuery = request.query
+        baseUrlComponents.percentEncodedPath += request.soar_pathOnly
+        baseUrlComponents.percentEncodedQuery = request.soar_query.map(String.init)
         guard let url = baseUrlComponents.url else {
             throw Error.invalidRequestURL(request: request, baseURL: baseURL)
         }
         var clientRequest = HTTPClientRequest(url: url.absoluteString)
         clientRequest.method = request.method.asHTTPMethod
         for header in request.headerFields {
-            clientRequest.headers.add(name: header.name.lowercased(), value: header.value)
+            clientRequest.headers.add(name: header.name.canonicalName, value: header.value)
         }
-        if let body = request.body {
-            clientRequest.body = .bytes(body)
+        if let body {
+            let length: HTTPClientRequest.Body.Length
+            switch body.length {
+            case .unknown:
+                length = .unknown
+            case .known(let count):
+                length = .known(count)
+            }
+            clientRequest.body = .stream(
+                body.map { .init(bytes: $0) },
+                length: length
+            )
         }
         return clientRequest
     }
@@ -180,18 +193,32 @@ public struct AsyncHTTPClientTransport: ClientTransport {
     /// Converts the received URLResponse into the shared Response.
     internal static func convertResponse(
         _ httpResponse: HTTPClientResponse
-    ) async throws -> OpenAPIRuntime.Response {
-        let headerFields: [OpenAPIRuntime.HeaderField] = httpResponse
-            .headers
-            .map { .init(name: $0, value: $1) }
-        let body = try await httpResponse.body.collect(upTo: .max)
-        let bodyData = Data(buffer: body, byteTransferStrategy: .noCopy)
-        let response = OpenAPIRuntime.Response(
-            statusCode: Int(httpResponse.status.code),
-            headerFields: headerFields,
-            body: bodyData
+    ) async throws -> (HTTPResponse, HTTPBody) {
+
+        var headerFields: HTTPFields = [:]
+        for header in httpResponse.headers {
+            headerFields[.init(header.name)!] = header.value
+        }
+
+        let length: HTTPBody.Length
+        if let lengthHeaderString = headerFields[.contentLength],
+            let lengthHeader = Int(lengthHeaderString)
+        {
+            length = .known(lengthHeader)
+        } else {
+            length = .unknown
+        }
+
+        let body = HTTPBody(
+            sequence: httpResponse.body.map { HTTPBody.ByteChunk($0.readableBytesView) },
+            length: length,
+            iterationBehavior: .single
         )
-        return response
+        let response = HTTPResponse(
+            status: .init(code: Int(httpResponse.status.code)),
+            headerFields: headerFields
+        )
+        return (response, body)
     }
 
     // MARK: Private
@@ -206,7 +233,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
     }
 }
 
-extension OpenAPIRuntime.HTTPMethod {
+extension HTTPTypes.HTTPRequest.Method {
     var asHTTPMethod: NIOHTTP1.HTTPMethod {
         switch self {
         case .get:

--- a/Sources/OpenAPIAsyncHTTPClient/Documentation.docc/Documentation.md
+++ b/Sources/OpenAPIAsyncHTTPClient/Documentation.docc/Documentation.md
@@ -20,7 +20,7 @@ Add the package dependency in your `Package.swift`:
 ```swift
 .package(
     url: "https://github.com/swift-server/swift-openapi-async-http-client", 
-    .upToNextMinor(from: "0.2.0")
+    .upToNextMinor(from: "0.3.0")
 ),
 ```
 

--- a/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
+++ b/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
@@ -39,8 +39,10 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
 
     func testConvertRequest() throws {
         let request: HTTPRequest = .init(
-            soar_path: "/hello%20world/Maria?greeting=Howdy",
             method: .post,
+            scheme: nil,
+            authority: nil,
+            path: "/hello%20world/Maria?greeting=Howdy",
             headerFields: [
                 .contentType: "application/json"
             ]
@@ -93,8 +95,10 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
             requestSender: TestSender.test
         )
         let request: HTTPRequest = .init(
-            soar_path: "/api/v1/hello/Maria",
             method: .get,
+            scheme: nil,
+            authority: nil,
+            path: "/api/v1/hello/Maria",
             headerFields: [
                 .init("x-request")!: "yes"
             ]

--- a/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
+++ b/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
@@ -79,7 +79,7 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
                 .contentType: "application/json"
             ]
         )
-        let bufferedResponseBody = try await responseBody.collectAsData(upTo: .max)
+        let bufferedResponseBody = try await Data(collecting: responseBody, upTo: .max)
         XCTAssertEqual(bufferedResponseBody, try Self.testData)
     }
 
@@ -105,7 +105,7 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
             baseURL: Self.testUrl,
             operationID: "sayHello"
         )
-        let bufferedResponseBody = try await responseBody.collectAsString(upTo: .max)
+        let bufferedResponseBody = try await String(collecting: responseBody, upTo: .max)
         XCTAssertEqual(bufferedResponseBody, "[{}]")
         XCTAssertEqual(response.status.code, 200)
     }

--- a/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
+++ b/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
@@ -17,6 +17,7 @@ import NIOCore
 import NIOPosix
 import AsyncHTTPClient
 @testable import OpenAPIAsyncHTTPClient
+import HTTPTypes
 
 class Test_AsyncHTTPClientTransport: XCTestCase {
 
@@ -37,17 +38,17 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
     }
 
     func testConvertRequest() throws {
-        let request: OpenAPIRuntime.Request = .init(
-            path: "/hello%20world/Maria",
-            query: "greeting=Howdy",
+        let request: HTTPRequest = .init(
+            soar_path: "/hello%20world/Maria?greeting=Howdy",
             method: .post,
             headerFields: [
-                .init(name: "content-type", value: "application/json")
-            ],
-            body: try Self.testData
+                .contentType: "application/json"
+            ]
         )
+        let requestBody = try HTTPBody(data: Self.testData)
         let httpRequest = try AsyncHTTPClientTransport.convertRequest(
             request,
+            body: requestBody,
             baseURL: try XCTUnwrap(URL(string: "http://example.com/api/v1"))
         )
         XCTAssertEqual(httpRequest.url, "http://example.com/api/v1/hello%20world/Maria?greeting=Howdy")
@@ -70,23 +71,20 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
             ],
             body: .bytes(Self.testBuffer)
         )
-        let response = try await AsyncHTTPClientTransport.convertResponse(httpResponse)
-        XCTAssertEqual(response.statusCode, 200)
+        let (response, responseBody) = try await AsyncHTTPClientTransport.convertResponse(httpResponse)
+        XCTAssertEqual(response.status.code, 200)
         XCTAssertEqual(
             response.headerFields,
             [
-                .init(name: "content-type", value: "application/json")
+                .contentType: "application/json"
             ]
         )
-        XCTAssertEqual(response.body, try Self.testData)
+        let bufferedResponseBody = try await responseBody.collectAsData(upTo: .max)
+        XCTAssertEqual(bufferedResponseBody, try Self.testData)
     }
 
     func testSend() async throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let httpClient = HTTPClient(
-            eventLoopGroupProvider: .shared(eventLoopGroup),
-            configuration: .init()
-        )
+        let httpClient = HTTPClient()
         defer {
             try! httpClient.syncShutdown()
         }
@@ -94,19 +92,22 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
             configuration: .init(client: httpClient),
             requestSender: TestSender.test
         )
-        let request: OpenAPIRuntime.Request = .init(
-            path: "/api/v1/hello/Maria",
+        let request: HTTPRequest = .init(
+            soar_path: "/api/v1/hello/Maria",
             method: .get,
             headerFields: [
-                .init(name: "x-request", value: "yes")
+                .init("x-request")!: "yes"
             ]
         )
-        let response = try await transport.send(
+        let (response, responseBody) = try await transport.send(
             request,
+            body: nil,
             baseURL: Self.testUrl,
             operationID: "sayHello"
         )
-        XCTAssertEqual(response.statusCode, 200)
+        let bufferedResponseBody = try await responseBody.collectAsString(upTo: .max)
+        XCTAssertEqual(bufferedResponseBody, "[{}]")
+        XCTAssertEqual(response.status.code, 200)
     }
 }
 

--- a/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
+++ b/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
@@ -71,7 +71,11 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
             ],
             body: .bytes(Self.testBuffer)
         )
-        let (response, responseBody) = try await AsyncHTTPClientTransport.convertResponse(httpResponse)
+        let (response, maybeResponseBody) = try await AsyncHTTPClientTransport.convertResponse(
+            method: .get,
+            httpResponse: httpResponse
+        )
+        let responseBody = try XCTUnwrap(maybeResponseBody)
         XCTAssertEqual(response.status.code, 200)
         XCTAssertEqual(
             response.headerFields,
@@ -99,12 +103,13 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
                 .init("x-request")!: "yes"
             ]
         )
-        let (response, responseBody) = try await transport.send(
+        let (response, maybeResponseBody) = try await transport.send(
             request,
             body: nil,
             baseURL: Self.testUrl,
             operationID: "sayHello"
         )
+        let responseBody = try XCTUnwrap(maybeResponseBody)
         let bufferedResponseBody = try await String(collecting: responseBody, upTo: .max)
         XCTAssertEqual(bufferedResponseBody, "[{}]")
         XCTAssertEqual(response.status.code, 200)

--- a/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
+++ b/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
@@ -45,7 +45,7 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
                 .contentType: "application/json"
             ]
         )
-        let requestBody = try HTTPBody(data: Self.testData)
+        let requestBody = try HTTPBody(Self.testData)
         let httpRequest = try AsyncHTTPClientTransport.convertRequest(
             request,
             body: requestBody,


### PR DESCRIPTION
### Motivation

AHC transport changes of the approved proposals apple/swift-openapi-generator#255 and apple/swift-openapi-generator#254.

### Modifications

- Adapts to the runtime changes, depends on HTTPTypes now.
- Both request and response streaming works.

### Result

Transport works with the 0.3.0 runtime API of.

### Test Plan

Adapted tests.
