### PR TITLE
Make the input HTTPClient required

### DIFF
--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -32,7 +32,13 @@ import protocol Foundation.LocalizedError
 ///
 /// Instantiate the transport:
 ///
-///     let transport = AsyncHTTPClientTransport()
+///     let httpClient = HTTPClient()
+///     defer {
+///         try! httpClient.syncShutdown()
+///     }
+///     let transport = AsyncHTTPClientTransport(
+///         configuration: .init(client: httpClient)
+///     )
 ///
 /// Create the base URL of the server to call using your client. If the server
 /// URL was defined in the OpenAPI document, you find a generated method for it
@@ -75,7 +81,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
         /// - Parameters:
         ///   - client: The underlying client used to perform HTTP operations.
         ///   - timeout: The request timeout, defaults to 1 minute.
-        public init(client: HTTPClient = .init(), timeout: TimeAmount = .minutes(1)) {
+        public init(client: HTTPClient, timeout: TimeAmount = .minutes(1)) {
             self.client = client
             self.timeout = timeout
         }


### PR DESCRIPTION
### Motivation

We previously defaulted the HTTPClient to `.init()`, but that's not correct as it was never getting shut down.

### Modifications

Removed the default value, which is a breaking change, so will need to be rolled out with 0.3.0.

### Result

No more crashing clients on dealloc.

### Test Plan

N/A
