### PR TITLE
Adopt a custom shared client

### DIFF
--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -74,7 +74,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
         /// in AsyncHTTPClient. Do not use this value directly, outside of
         /// the `Configuration.init(client:timeout:)` initializer, as it will
         /// likely be removed in the future.
-        public static let sharedClient: HTTPClient = .init()
+        private static let sharedClient: HTTPClient = .init()
 
         /// The default request timeout.
         public var timeout: TimeAmount
@@ -82,9 +82,10 @@ public struct AsyncHTTPClientTransport: ClientTransport {
         /// Creates a new configuration with the specified client and timeout.
         /// - Parameters:
         ///   - client: The underlying client used to perform HTTP operations.
+        ///     Provide nil to use the shared internal client.
         ///   - timeout: The request timeout, defaults to 1 minute.
-        public init(client: HTTPClient = Self.sharedClient, timeout: TimeAmount = .minutes(1)) {
-            self.client = client
+        public init(client: HTTPClient? = nil, timeout: TimeAmount = .minutes(1)) {
+            self.client = Self.sharedClient
             self.timeout = timeout
         }
     }

--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -68,6 +68,14 @@ public struct AsyncHTTPClientTransport: ClientTransport {
         /// The HTTP client used for performing HTTP calls.
         public var client: HTTPClient
 
+        /// The default shared HTTP client.
+        ///
+        /// This is a workaround for the lack of a shared client
+        /// in AsyncHTTPClient. Do not use this value directly, outside of
+        /// the `Configuration.init(client:timeout:)` initializer, as it will
+        /// likely be removed in the future.
+        public static let sharedClient: HTTPClient = .init()
+
         /// The default request timeout.
         public var timeout: TimeAmount
 
@@ -75,7 +83,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
         /// - Parameters:
         ///   - client: The underlying client used to perform HTTP operations.
         ///   - timeout: The request timeout, defaults to 1 minute.
-        public init(client: HTTPClient = .init(), timeout: TimeAmount = .minutes(1)) {
+        public init(client: HTTPClient = Self.sharedClient, timeout: TimeAmount = .minutes(1)) {
             self.client = client
             self.timeout = timeout
         }

--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -85,7 +85,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
         ///     Provide nil to use the shared internal client.
         ///   - timeout: The request timeout, defaults to 1 minute.
         public init(client: HTTPClient? = nil, timeout: TimeAmount = .minutes(1)) {
-            self.client = Self.sharedClient
+            self.client = client ?? Self.sharedClient
             self.timeout = timeout
         }
     }

--- a/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
+++ b/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
@@ -82,16 +82,8 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
     }
 
     func testSend() async throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let httpClient = HTTPClient(
-            eventLoopGroupProvider: .shared(eventLoopGroup),
-            configuration: .init()
-        )
-        defer {
-            try! httpClient.syncShutdown()
-        }
         let transport = AsyncHTTPClientTransport(
-            configuration: .init(client: httpClient),
+            configuration: .init(),
             requestSender: TestSender.test
         )
         let request: OpenAPIRuntime.Request = .init(


### PR DESCRIPTION
### Motivation

We previously defaulted the HTTPClient to .init(), but that's not correct as it was never getting shut down.

### Modifications

Instead of creating a new client, just introduce our own shared one and use that as the default value.

Once AHC provides a shared client, we can default to that in the configuration initializer.

### Result

No more crashing clients on dealloc.

### Test Plan

All tests pass.
