### PR TITLE
Bump swift-format to 5.9

### DIFF
--- a/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
+++ b/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
@@ -119,8 +119,7 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
 struct TestSender: HTTPRequestSending {
     var sendClosure:
         @Sendable (AsyncHTTPClientTransport.Request, HTTPClient, TimeAmount) async throws ->
-            AsyncHTTPClientTransport
-            .Response
+            AsyncHTTPClientTransport.Response
     func send(
         request: AsyncHTTPClientTransport.Request,
         with client: HTTPClient,

--- a/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
+++ b/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
@@ -118,7 +118,8 @@ class Test_AsyncHTTPClientTransport: XCTestCase {
 
 struct TestSender: HTTPRequestSending {
     var sendClosure:
-        @Sendable (AsyncHTTPClientTransport.Request, HTTPClient, TimeAmount) async throws -> AsyncHTTPClientTransport
+        @Sendable (AsyncHTTPClientTransport.Request, HTTPClient, TimeAmount) async throws ->
+            AsyncHTTPClientTransport
             .Response
     func send(
         request: AsyncHTTPClientTransport.Request,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p $HOME/.tools
 RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 
 # swift-format
-ARG swiftformat_version=508.0.0
+ARG swiftformat_version=509.0.0
 RUN git clone --branch $swiftformat_version --depth 1 https://github.com/apple/swift-format $HOME/.tools/swift-format-source
 RUN cd $HOME/.tools/swift-format-source && swift build -c release
 RUN ln -s $HOME/.tools/swift-format-source/.build/release/swift-format $HOME/.tools/swift-format


### PR DESCRIPTION
### Motivation

As per https://github.com/apple/swift-openapi-generator/issues/175.

### Modifications

Bump swift-format, update to make soundness pass.

### Result

Using swift-format 5.9.

### Test Plan

Soundness passed.
