### PR TITLE
Enable documentation comment validation in swift-format

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -16,7 +16,7 @@
   "prioritizeKeepingFunctionOutputTogether" : false,
   "respectsExistingLineBreaks" : true,
   "rules" : {
-    "AllPublicDeclarationsHaveDocumentation" : false,
+    "AllPublicDeclarationsHaveDocumentation" : true,
     "AlwaysUseLowerCamelCase" : false,
     "AmbiguousTrailingClosureOverload" : true,
     "BeginDocumentationCommentWithOneLineSummary" : false,
@@ -50,7 +50,7 @@
     "UseSynthesizedInitializer" : true,
     "UseTripleSlashForDocumentationComments" : true,
     "UseWhereClausesInForLoops" : false,
-    "ValidateDocumentationComments" : false
+    "ValidateDocumentationComments" : true
   },
   "spacesAroundRangeFormationOperators" : false,
   "tabWidth" : 8,

--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -139,8 +139,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
     }
 
     /// Creates a new transport.
-    /// - Parameters:
-    ///   - configuration: A set of configuration values used by the transport.
+    /// - Parameter configuration: A set of configuration values used by the transport.
     public init(configuration: Configuration) {
         self.init(
             configuration: configuration,
@@ -150,6 +149,16 @@ public struct AsyncHTTPClientTransport: ClientTransport {
 
     // MARK: ClientTransport
 
+    /// Sends an HTTP request and returns the corresponding HTTP response.
+    ///
+    /// - Parameters:
+    ///   - request: The HTTP request to send.
+    ///   - body: The HTTP body to include in the request (optional).
+    ///   - baseURL: The base URL for the request.
+    ///   - operationID: The identifier for the operation.
+    ///
+    /// - Returns: A tuple containing the HTTP response and an optional HTTP body in the response.
+    /// - Throws: An error if the request or response handling encounters any issues.
     public func send(
         _ request: HTTPRequest,
         body: HTTPBody?,


### PR DESCRIPTION
### Motivation

-  Relates to https://github.com/apple/swift-openapi-generator/issues/165

### Modifications

- Enable new rules in swift-format and address changes required

### Result

- There will be new swift format rules enabled

### Test Plan

- Run all tests
