### PR TITLE
Add a soundness --fix flag

### DIFF
--- a/scripts/run-swift-format.sh
+++ b/scripts/run-swift-format.sh
@@ -21,10 +21,17 @@ fatal() { error "$@"; exit 1; }
 CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="$(git -C "${CURRENT_SCRIPT_DIR}" rev-parse --show-toplevel)"
 
+FORMAT_COMMAND="lint --strict"
+for arg in "$@"; do
+  if [ "$arg" == "--fix" ]; then
+    FORMAT_COMMAND="format --in-place"
+  fi
+done
+
 SWIFTFORMAT_BIN=${SWIFTFORMAT_BIN:-$(command -v swift-format)} || fatal "❌ SWIFTFORMAT_BIN unset and no swift-format on PATH"
 
-"${SWIFTFORMAT_BIN}" lint \
-  --parallel --recursive --strict \
+"${SWIFTFORMAT_BIN}" $FORMAT_COMMAND \
+  --parallel --recursive \
   "${REPO_ROOT}/Sources" "${REPO_ROOT}/Tests" \
   && SWIFT_FORMAT_RC=$? || SWIFT_FORMAT_RC=$?
 
@@ -33,7 +40,7 @@ if [ "${SWIFT_FORMAT_RC}" -ne 0 ]; then
 
   To fix, run the following command:
 
-    % swift-format format --parallel --recursive --in-place Sources Tests
+    % ./scripts/run-swift-format.sh --fix
   "
   exit "${SWIFT_FORMAT_RC}"
 fi

--- a/scripts/run-swift-format.sh
+++ b/scripts/run-swift-format.sh
@@ -21,16 +21,16 @@ fatal() { error "$@"; exit 1; }
 CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="$(git -C "${CURRENT_SCRIPT_DIR}" rev-parse --show-toplevel)"
 
-FORMAT_COMMAND="lint --strict"
+FORMAT_COMMAND=(lint --strict)
 for arg in "$@"; do
   if [ "$arg" == "--fix" ]; then
-    FORMAT_COMMAND="format --in-place"
+    FORMAT_COMMAND=(format --in-place)
   fi
 done
 
 SWIFTFORMAT_BIN=${SWIFTFORMAT_BIN:-$(command -v swift-format)} || fatal "❌ SWIFTFORMAT_BIN unset and no swift-format on PATH"
 
-"${SWIFTFORMAT_BIN}" $FORMAT_COMMAND \
+"${SWIFTFORMAT_BIN}" "$FORMAT_COMMAND" \
   --parallel --recursive \
   "${REPO_ROOT}/Sources" "${REPO_ROOT}/Tests" \
   && SWIFT_FORMAT_RC=$? || SWIFT_FORMAT_RC=$?

--- a/scripts/run-swift-format.sh
+++ b/scripts/run-swift-format.sh
@@ -30,7 +30,7 @@ done
 
 SWIFTFORMAT_BIN=${SWIFTFORMAT_BIN:-$(command -v swift-format)} || fatal "❌ SWIFTFORMAT_BIN unset and no swift-format on PATH"
 
-"${SWIFTFORMAT_BIN}" "$FORMAT_COMMAND" \
+"${SWIFTFORMAT_BIN}" "${FORMAT_COMMAND[@]}" \
   --parallel --recursive \
   "${REPO_ROOT}/Sources" "${REPO_ROOT}/Tests" \
   && SWIFT_FORMAT_RC=$? || SWIFT_FORMAT_RC=$?

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -22,11 +22,17 @@ CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 NUM_CHECKS_FAILED=0
 export DOCC_TARGET=OpenAPIAsyncHTTPClient
 
+FIX_FORMAT=""
+for arg in "$@"; do
+  if [ "$arg" == "--fix" ]; then
+    FIX_FORMAT="--fix"
+  fi
+done
+
 SCRIPT_PATHS=(
   "${CURRENT_SCRIPT_DIR}/check-for-broken-symlinks.sh"
   "${CURRENT_SCRIPT_DIR}/check-for-unacceptable-language.sh"
   "${CURRENT_SCRIPT_DIR}/check-license-headers.sh"
-  "${CURRENT_SCRIPT_DIR}/run-swift-format.sh"
   "${CURRENT_SCRIPT_DIR}/check-for-docc-warnings.sh"
 )
 
@@ -36,6 +42,13 @@ for SCRIPT_PATH in "${SCRIPT_PATHS[@]}"; do
     ((NUM_CHECKS_FAILED+=1))
   fi
 done
+
+log "Running swift-format..."
+bash ${CURRENT_SCRIPT_DIR}/run-swift-format.sh $FIX_FORMAT > /dev/null
+FORMAT_EXIT_CODE=$?
+if [ $FORMAT_EXIT_CODE -ne 0 ]; then
+  ((NUM_CHECKS_FAILED+=1))
+fi
 
 if [ "${NUM_CHECKS_FAILED}" -gt 0 ]; then
   fatal "❌ ${NUM_CHECKS_FAILED} soundness check(s) failed."


### PR DESCRIPTION
### Motivation

When running `./scripts/soundness.sh` produces swift-format warnings, we ask adopters to manually copy/paste a call to swift format to fix the warnings up. This is tedious and unnecessary.

### Modifications

Add a `--fix` option on the `soundness.sh` script to actually apply the fixes as well, avoiding the need to copy/paste long commands.

### Result

Easier fixing up of formatting warnings.

### Test Plan

Manually tested the workflow locally.
