### PR TITLE
Disable "respectsExistingLineBreaks" in .swift-format for more consistent styling

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -14,7 +14,7 @@
   "lineLength" : 120,
   "maximumBlankLines" : 1,
   "prioritizeKeepingFunctionOutputTogether" : false,
-  "respectsExistingLineBreaks" : true,
+  "respectsExistingLineBreaks" : false,
   "rules" : {
     "AllPublicDeclarationsHaveDocumentation" : true,
     "AlwaysUseLowerCamelCase" : false,


### PR DESCRIPTION
### Motivation

- Relates to [#230](https://github.com/apple/swift-openapi-generator/issues/230)

### Modifications

- Disable respectsExistingLineBreaks .swift-format rule and address changes requested

### Result

- One of the .swift-format rules will be disabled

### Test Plan

- Run Tests
