### PR TITLE
Prep for 1.0 alpha, adapted to runtime changes in main

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio", from: "2.58.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
-        .package(url: "https://github.com/apple/swift-openapi-runtime", .upToNextMinor(from: "0.3.0")),
+        .package(url: "https://github.com/apple/swift-openapi-runtime", branch: "main"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -181,7 +181,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
             let length: HTTPClientRequest.Body.Length
             switch body.length {
             case .unknown: length = .unknown
-            case .known(let count): length = .known(count)
+            case .known(let count): length = .known(Int(count))
             }
             clientRequest.body = .stream(body.map { .init(bytes: $0) }, length: length)
         }
@@ -197,7 +197,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
         for header in httpResponse.headers { headerFields[.init(header.name)!] = header.value }
 
         let length: HTTPBody.Length
-        if let lengthHeaderString = headerFields[.contentLength], let lengthHeader = Int(lengthHeaderString) {
+        if let lengthHeaderString = headerFields[.contentLength], let lengthHeader = Int64(lengthHeaderString) {
             length = .known(lengthHeader)
         } else {
             length = .unknown


### PR DESCRIPTION
### Motivation

On main, the HTTPBody length type changed from Int to Int64.

### Modifications

Adapted the transport with this change.

### Result

Repo builds again when using the latest runtime.

### Test Plan

Adapted tests.
