### PR TITLE
Remove #if swift(>=5.9) check in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,15 +16,11 @@ import Foundation
 import PackageDescription
 
 // General Swift-settings for all targets.
-var swiftSettings: [SwiftSetting] = []
-
-#if swift(>=5.9)
-swiftSettings.append(
+let swiftSettings: [SwiftSetting] = [
     // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
     // Require `any` for existential types.
     .enableUpcomingFeature("ExistentialAny")
-)
-#endif
+]
 
 let package = Package(
     name: "swift-openapi-async-http-client",


### PR DESCRIPTION
### Motivation

In #26 we bumped the minimum tools version to Swift 5.9, but we left the `#if swift(>5.9)` compiler directive when enabling existential any by default.

### Modifications

Remove #if swift(>=5.9) check in Package.swift

### Result

No checking for Swift 5.9+, because that's now the default.

### Test Plan

CI.