### PR TITLE
Handle large payloads on 32bit platforms gracefully

### DIFF
--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -181,7 +181,8 @@ public struct AsyncHTTPClientTransport: ClientTransport {
             let length: HTTPClientRequest.Body.Length
             switch body.length {
             case .unknown: length = .unknown
-            case .known(let count): length = .known(Int(count))
+            case .known(let count):
+                if let intValue = Int(exactly: count) { length = .known(intValue) } else { length = .unknown }
             }
             clientRequest.body = .stream(body.map { .init(bytes: $0) }, length: length)
         }


### PR DESCRIPTION
### Motivation

If there's a request payload with a number of bytes that can't fit into 32 bits, we'd crash.

### Modifications

Use a graceful initializer and use `.unknown` (so no `content-length` will be sent) if the size exceeds the max of a 32bit int.

### Result

No crash for large payloads on 32bit platforms.

### Test Plan

Tests pass.
