### PR TITLE
Default the configuration parameter

### DIFF
--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -135,7 +135,7 @@ public struct AsyncHTTPClientTransport: ClientTransport {
 
     /// Creates a new transport.
     /// - Parameter configuration: A set of configuration values used by the transport.
-    public init(configuration: Configuration) {
+    public init(configuration: Configuration = .init()) {
         self.init(configuration: configuration, requestSender: AsyncHTTPRequestSender())
     }
 


### PR DESCRIPTION
### Motivation

The AsyncHTTPClient transport API has undergone changes in recent months and we didn't bring back the default initializer after we adopted the shared EventLoopGroup, allowing you to create a transport with just `let transport = AsyncHTTPClientTransport()`.

### Modifications

Default the configuration parameter in the initializer to be able to do that. It's already documented to work, but it doesn't.

### Result

Match the documented behavior of being able to use `let transport = AsyncHTTPClientTransport()`.

### Test Plan

Tests still pass.
