### PR TITLE
Explicit dependency on HTTPTypes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio", from: "2.58.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/apple/swift-http-types", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
@@ -44,6 +45,7 @@ let package = Package(
             name: "OpenAPIAsyncHTTPClient",
             dependencies: [
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
+                .product(name: "HTTPTypes", package: "swift-http-types"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
             ],


### PR DESCRIPTION
### Motivation

Recent SwiftPM versions seem to be a bit stricter about using (i.e., `import ...`) transitive dependencies without explicitly declaring them as direct dependencies.

### Modifications

Explicitly depend on the HTTPTypes module from swift-http-types.

### Result

More explicitly declare the dependency graph.

### Test Plan

All tests pass.
