### PR TITLE
Add issue template, redirecting to swift-openapi-generator issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🐞 Open an issue on the Swift OpenAPI Generator repository
+    url: https://github.com/apple/swift-openapi-generator/issues
+    about: >
+      Issues for all repositories in the Swift OpenAPI Generator project are centralized in the swift-openapi-generator repository.


### PR DESCRIPTION
### Motivation

We centralize the issues for all the repos in the Swift OpenAPI Generator project in the generator repo. Using an issue template will make this even clearer, because it will allow people to use the normal Github workflow to discover the process and provide a link to where to file their issue.

### Modifications

Add issue template, redirecting to swift-openapi-generator issues.

### Result

When people try and file an issue, they'll be presented with a button that takes them to the generator repo issues page.

### Test Plan

Manual.