### PR TITLE
Use `HTTPClient.shared` as default

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio", from: "2.58.0"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.21.0"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-http-types", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,9 @@ import PackageDescription
 let swiftSettings: [SwiftSetting] = [
     // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
     // Require `any` for existential types.
-    .enableUpcomingFeature("ExistentialAny")
+    .enableUpcomingFeature("ExistentialAny"),
+    // Enable Strict Concurrency Checks for Swift 6 compatibility.
+    .enableExperimentalFeature("StrictConcurrency=complete"),
 ]
 
 let package = Package(

--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -17,7 +17,7 @@ import NIOCore
 import NIOHTTP1
 import NIOFoundationCompat
 import HTTPTypes
-#if canImport(Darwin) || swift(<6.0)
+#if canImport(Darwin) || swift(>=6.0)
 import Foundation
 #else
 @preconcurrency import struct Foundation.URL

--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -62,24 +62,18 @@ public struct AsyncHTTPClientTransport: ClientTransport {
         /// The HTTP client used for performing HTTP calls.
         public var client: HTTPClient
 
-        /// The default shared HTTP client.
-        ///
-        /// This is a workaround for the lack of a shared client
-        /// in AsyncHTTPClient. Do not use this value directly, outside of
-        /// the `Configuration.init(client:timeout:)` initializer, as it will
-        /// likely be removed in the future.
-        private static let sharedClient: HTTPClient = .init()
-
         /// The default request timeout.
         public var timeout: TimeAmount
 
         /// Creates a new configuration with the specified client and timeout.
         /// - Parameters:
         ///   - client: The underlying client used to perform HTTP operations.
-        ///     Provide nil to use the shared internal client.
+        ///     Provide nil to use `HTTPClient.shared`.
         ///   - timeout: The request timeout, defaults to 1 minute.
         public init(client: HTTPClient? = nil, timeout: TimeAmount = .minutes(1)) {
-            self.client = client ?? Self.sharedClient
+            // FIXME: `client: HTTPClient? = nil` should be changed to `client: HTTPClient = .shared`
+            // in a future major version, now that `AsyncHTTPClient` provides a shared `HTTPClient`.
+            self.client = client ?? HTTPClient.shared
             self.timeout = timeout
         }
     }

--- a/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
+++ b/Sources/OpenAPIAsyncHTTPClient/AsyncHTTPClientTransport.swift
@@ -17,7 +17,7 @@ import NIOCore
 import NIOHTTP1
 import NIOFoundationCompat
 import HTTPTypes
-#if canImport(Darwin)
+#if canImport(Darwin) || swift(<6.0)
 import Foundation
 #else
 @preconcurrency import struct Foundation.URL


### PR DESCRIPTION
### Motivation

AHC provides a shared `HTTPClient` now so we should use that instead of creating our own.

### Modifications

Use `HTTPClient.shared` as the default `HTTPClient`.

### Result

Apps won't be using 2 different shared `HTTPClient`s.

### Test Plan

The change does not seem to need test changes.
