### PR TITLE
Enable MemberImportVisibility check on all targets

### DIFF
--- a/.swiftformatignore
+++ b/.swiftformatignore
@@ -1,0 +1,1 @@
+**Package.swift

--- a/Package.swift
+++ b/Package.swift
@@ -50,3 +50,14 @@ let package = Package(
         ),
     ]
 )
+
+// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
+for target in package.targets {
+    if target.type != .plugin {
+        var settings = target.swiftSettings ?? []
+        // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+        settings.append(.enableUpcomingFeature("MemberImportVisibility"))
+        target.swiftSettings = settings
+    }
+}
+// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //

--- a/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
+++ b/Tests/OpenAPIAsyncHTTPClientTests/Test_AsyncHTTPClientTransport.swift
@@ -14,6 +14,7 @@
 import XCTest
 import OpenAPIRuntime
 import NIOCore
+import NIOHTTP1
 import NIOPosix
 import AsyncHTTPClient
 @testable import OpenAPIAsyncHTTPClient


### PR DESCRIPTION
Enable MemberImportVisibility check on all targets. Use a standard string header and footer to bracket the new block for ease of updating in the future with scripts.