### PR TITLE
Only apply standard swift settings on valid targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ import PackageDescription
 let swiftSettings: [SwiftSetting] = [
     // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
     // Require `any` for existential types.
-    .enableUpcomingFeature("ExistentialAny"), .enableExperimentalFeature("StrictConcurrency=complete"),
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableExperimentalFeature("StrictConcurrency=complete"),
 ]
 
 let package = Package(
@@ -62,4 +63,5 @@ for target in package.targets {
     case .macro, .plugin, .system, .binary: ()  // not applicable
     @unknown default: ()  // we don't know what to do here, do nothing
     }
-}// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //
+}
+// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,7 @@ import PackageDescription
 let swiftSettings: [SwiftSetting] = [
     // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
     // Require `any` for existential types.
-    .enableUpcomingFeature("ExistentialAny"),
-    .enableExperimentalFeature("StrictConcurrency=complete"),
+    .enableUpcomingFeature("ExistentialAny"), .enableExperimentalFeature("StrictConcurrency=complete"),
 ]
 
 let package = Package(
@@ -54,11 +53,13 @@ let package = Package(
 
 // ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
 for target in package.targets {
-    if target.type != .plugin {
+    switch target.type {
+    case .regular, .test, .executable:
         var settings = target.swiftSettings ?? []
         // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
         settings.append(.enableUpcomingFeature("MemberImportVisibility"))
         target.swiftSettings = settings
+    case .macro, .plugin, .system, .binary: ()  // not applicable
+    @unknown default: ()  // we don't know what to do here, do nothing
     }
-}
-// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //
+}// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //


### PR DESCRIPTION
Only apply standard swift settings on valid targets. The current check ignores plugins but that is not comprehensive enough.