### PR TITLE
update `actions/checkout` from v4 to v6

### DIFF
--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Check for Semantic Version label


### PR DESCRIPTION
Motivation

* Following [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026. Node 20 will reach end-of-life in April 2026.

Modifications

* Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24.
* Replace `actions/checkout@v4` with `actions/checkout@v6` in all workflow files.

Result

* Workflow files reference `actions/checkout@v6`.
